### PR TITLE
test: Fix trusted test - use python script

### DIFF
--- a/tests/tests_trusted_execution.yml
+++ b/tests/tests_trusted_execution.yml
@@ -39,9 +39,10 @@
         - name: Create shell executables
           copy:
             content: |
-              #/bin/bash
+              #!/usr/bin/python
               # this is item {{ item }}
-              exit 0
+              import sys
+              sys.exit(0)
             dest: "{{ item }}"
             mode: "0755"
           loop:


### PR DESCRIPTION
fapolicyd does not work with shell scripts.  In addition, the
shell script was broken.  Instead, use a python script.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
