### PR TITLE
ci: Add supported_ansible_also to .ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -22,3 +22,5 @@ exclude_paths:
   - examples/roles/
 mock_roles:
   - linux-system-roles.fapolicyd
+supported_ansible_also:
+  - "2.14.0"


### PR DESCRIPTION
This fixes the breakage of ansible-test.

We want to advertise support for ansible 2.14 since some of
our collections will be supported for a long time on this
version.  The latest version of ansible-lint requires 2.15
in meta/runtime.yml, but it also adds support for a way to
tell ansible-lint other versions which are acceptable, using
the new `supported_ansible_also` configuration option
in .ansible-lint

With this fix, we can support both the latest version of
ansible-test and ansible-lint.

See https://github.com/linux-system-roles/auto-maintenance/pull/341
for more information.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
