### PR TITLE
ci: Update fmf plan to add a separate job to prepare managed nodes

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -20,8 +20,6 @@ jobs:
     if: |
       github.event.issue.pull_request
       && (contains(github.event.comment.body, '[citest]') || contains(github.event.comment.body, '[citest-all]'))
-      && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association)
-      || contains('systemroller', github.event.comment.user.login))
     runs-on: ubuntu-latest
     outputs:
       supported_platforms: ${{ steps.supported_platforms.outputs.supported_platforms }}
@@ -151,7 +149,8 @@ jobs:
             GITHUB_ORG=linux-system-roles;\
             PR_NUM=${{ github.event.issue.number }};\
             ARTIFACTS_DIR=${{ env.ARTIFACTS_DIR }};\
-            ARTIFACTS_URL=${{ env.ARTIFACTS_URL }}"
+            ARTIFACTS_URL=${{ env.ARTIFACTS_URL }};\
+            TEST_LOCAL_CHANGES=false"
           # Note that LINUXSYSTEMROLES_SSH_KEY must be single-line, TF doesn't read multi-line variables fine.
           secrets: "LINUXSYSTEMROLES_USER=${{ secrets.LINUXSYSTEMROLES_USER }};\
             LINUXSYSTEMROLES_DOMAIN=${{ secrets.LINUXSYSTEMROLES_DOMAIN }};\

--- a/plans/README-plans.md
+++ b/plans/README-plans.md
@@ -21,15 +21,10 @@ You can run tests locally with the `tmt try` cli.
 
 ### Running Tests Locally
 
-For now, this functionality requires you to push changes to a PR because the plan only runs from the main branch, or from the PR branch.
-So this is WIP.
+To run tests locally, in the role repository, enter `tmt try -p plans/general <platform>`.
 
-To run tests locally, in the role repository, enter `tmt run plans --name plans/general <platform>`.
-Where `<platform>` is the name of the platform you want to run tests against.
+This command identifies the plans/general plan and provisions two local VMs, one used as an Ansible control node, and second used as a managed node.
 
-For example, `tmt run plans --name plans/general Fedora-40`.
+tmt try is in development and does not identify tests from URL automatically, so after provisioning the machines, you must type `t`, `p`, `t` from the interactive prompt to identify tests, run preparation steps, and run the tests.
 
-This command identifies the plans/general plan and provisions two machines, one used as an Ansible control node, and second used as a managed node.
-
-You can also use `tmt try` to get to an interreactive prompt and be able to ssh into test machines.
-You must run `tmt try -p plans/general Fedora-40`, and the in the promt type `p` to prepare the machines, then `t` to run the tests.
+You can modify environment variables in  `plans/general.fmf` to, e.g. run only specified test playbooks by overwriting `SYSTEM_ROLES_ONLY_TESTS`.

--- a/plans/general.fmf
+++ b/plans/general.fmf
@@ -2,9 +2,9 @@ summary: A general test for a system role
 provision:
   - name: control_node
     role: control_node
-    # TF uses `how: artemis`, tmt try uses `how: virtual`. No need to define `how`
-    # `connection: system` is for `how: virtual` to make VMs get a real IP to configure ssh easily
-    # This setting is ignored on artemis so we can keep it
+    # TF uses `how: artemis`, tmt try uses `how: virtual`. No need to define `how`.
+    # `connection: system` is for `how: virtual` to make VMs get a real IP to configure ssh easily.
+    # This setting is ignored on artemis so we can keep it.
     connection: system
   - name: managed_node1
     role: managed_node
@@ -13,45 +13,27 @@ environment:
     ANSIBLE_VER: 2.17
     REPO_NAME: fapolicyd
     PYTHON_VERSION: 3.12
-    SYSTEM_ROLES_ONLY_TESTS: ""
+    SYSTEM_ROLES_ONLY_TESTS: "" # e.g. tests_default.yml
     PR_NUM: ""
+    TEST_LOCAL_CHANGES: true
 prepare:
   - name: Use vault.centos.org repos (CS 7, 8 EOL workaround)
     script: |
       if grep -q -e 'CentOS Stream release 8' -e 'CentOS Linux release 7.9' /etc/redhat-release; then
         sed -i '/^mirror/d;s/#\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo
       fi
-
-  - name: Enable epel to install beakerlib on all platforms except CS10 and Fedora, there it's not available and not needed
+  - name: Enable epel to install beakerlib on all platforms except CS10 and Fedora, there epel not available and not needed
     script: |
       if ! grep -q -e 'CentOS Stream release 10' -e 'Fedora release' /etc/redhat-release; then
         yum install epel-release -y
       fi
-    where: control_node
-
-  - name: Additional steps to enable EPEL on EL 7
-    script: |
-      if grep -q 'CentOS Linux release 7.9' /etc/redhat-release; then
-        yum install yum-utils -y
-        yum-config-manager --enable epel epel-debuginfo epel-source
-      fi
-    where: control_node
-
-  - name: Install python on managed node when running CS8 with ansible!=2.9
-    script: |
-      if [ "$ANSIBLE_VER" != "2.9" ] && grep -q 'CentOS Stream release 8' /etc/redhat-release; then
-        dnf install -y python"$PYTHON_VERSION"
-      fi
-    where: managed_node
-
-  - name: Distribute SSH keys when provisioned with how=virtual
-    script: |
-      if [ -f ${TMT_TREE%/*}/provision/control_node/id_ecdsa.pub ]; then
-        cat ${TMT_TREE%/*}/provision/control_node/id_ecdsa.pub >> ~/.ssh/authorized_keys
-      fi
-    where: managed_node
-
 discover:
+  - name: Prepare managed node
+    how: fmf
+    url: https://github.com/linux-system-roles/tft-tests
+    ref: main
+    where: managed_node
+    filter: tag:prep_managed_node
   - name: Run test playbooks from control_node
     how: fmf
     url: https://github.com/linux-system-roles/tft-tests


### PR DESCRIPTION
* Add a preparation job to run on managed nodes
* Update instructions to run tests locally
* From tft workflow, remove condition for commenter author_association.
  This would require us to add all trusted users, running workflow is not dangerous.
* Keep the plan minimal, only run prep steps required to install beakerlib

Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
