### PR TITLE
test: make test_trusted_execution gather facts

### DIFF
--- a/tests/tests_trusted_execution.yml
+++ b/tests/tests_trusted_execution.yml
@@ -1,6 +1,7 @@
 ---
 - name: Basic test for fapolicyd
   hosts: all
+  gather_facts: true  # needed for python executable discovery
   tasks:
     - name: Run tests
       vars:


### PR DESCRIPTION
facts are needed for python interpreter discovery

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
