### PR TITLE
test: use ansible_python_interpreter

### DIFF
--- a/tests/tests_trusted_execution.yml
+++ b/tests/tests_trusted_execution.yml
@@ -50,10 +50,8 @@
             - "{{ __test_fpd_exe1 }}"
             - "{{ __test_fpd_exe2 }}"
           vars:
-            __python: "{{ '/usr/libexec/platform-python'
-              if (ansible_facts['distribution_major_version'] == '8' and
-                  ansible_facts['os_family'] == 'RedHat')
-              else '/usr/bin/python' }}"
+            __python: "{{ ansible_python_interpreter |
+              d(discovered_interpreter_python) }}"
 
         - name: Create a new user
           user:


### PR DESCRIPTION
The ostree testing was failing because /usr/bin/python was
not found.

Just use ansible_python_interpreter to use the same python
intepreter used by ansible.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
