### PR TITLE
ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.9.0"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.9.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.9.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -90,6 +90,12 @@ jobs:
         if: env.RELEASE_VERSION == 'latest'
         run: cp ${{ env.RELEASE_VERSION }}/README.html docs/index.html
 
+      - name: Upload README.html as an artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: README.html
+          path: ${{ env.RELEASE_VERSION }}/README.html
+
       - name: Commit changes
         run: |
           git config --global user.name "${{ github.actor }}"

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -105,7 +105,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.9.0"
 
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported
@@ -117,7 +117,8 @@ jobs:
         if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu')
         run: >-
           tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch
-          --log-level=debug --skip-tags tests::infiniband,tests::nvme,tests::scsi --
+          --log-level debug --skip-tags tests::infiniband,tests::nvme,tests::scsi
+          --lsr-report-errors-url DEFAULT --
 
       - name: Qemu result summary
         if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu') && always()
@@ -127,15 +128,18 @@ jobs:
           # actual test playbook that starts with tests_
           while read code start end test_files; do
               for f in $test_files; do
-                  f="$(basename $f)"
+                  test_file="$f"
+                  f="$(basename $test_file)"
                   if [[ "$f" =~ ^tests_ ]]; then
                       break
                   fi
               done
               if [ "$code" = "0" ]; then
                   echo -n "PASS: "
+                  mv "$test_file.log" "${test_file}-SUCCESS.log"
               else
                   echo -n "FAIL: "
+                  mv "$test_file.log" "${test_file}-FAIL.log"
               fi
               echo "$f"
           done < batch.report
@@ -151,8 +155,10 @@ jobs:
           for t in tests/tests_*.yml; do
               if tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} $t > ${t}.log 2>&1; then
                   echo "PASS: $(basename $t)"
+                  mv "${t}.log" "${t}-SUCCESS.log"
               else
                   echo "FAIL: $(basename $t)"
+                  mv "${t}.log" "${t}-FAIL.log"
                   rc=1
               fi
           done
@@ -175,13 +181,14 @@ jobs:
         if: steps.check_platform.outputs.supported && failure()
         run: |
           set -euo pipefail
-          for f in tests/*.log; do
-              if FAIL=$(grep -E -B100 -A30 "fatal:|An exception occurred" "$f"); then
-                  echo "::group::$(basename $f)"
-                  echo "$FAIL"
-                  echo "::endgroup::"
-              fi
+          # grab check_logs.py script
+          curl -s -L -o check_logs.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/refs/heads/main/check_logs.py
+          chmod +x check_logs.py
+          declare -a cmdline=(./check_logs.py --github-action-format)
+          for log in tests/*-FAIL.log; do
+              cmdline+=(--lsr-error-log "$log")
           done
+          "${cmdline[@]}"
 
       - name: Set commit status as success with a description that platform is skipped
         if: ${{ steps.check_platform.outputs.supported == '' }}

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -72,8 +72,8 @@ jobs:
           meta_main=meta/main.yml
           # All Fedora are supported, add latest Fedora versions to supported_platforms
           if yq '.galaxy_info.galaxy_tags[]' "$meta_main" | grep -qi fedora$; then
-            supported_platforms+=" Fedora-40"
             supported_platforms+=" Fedora-41"
+            supported_platforms+=" Fedora-42"
           fi
           # Specific Fedora versions supported
           if yq '.galaxy_info.galaxy_tags[]' "$meta_main" | grep -qiP 'fedora\d+$'; then
@@ -98,9 +98,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: Fedora-40
-            ansible_version: 2.17
           - platform: Fedora-41
+            ansible_version: 2.17
+          - platform: Fedora-42
             ansible_version: 2.17
           - platform: CentOS-7-latest
             ansible_version: 2.9


### PR DESCRIPTION
Add Fedora 42 to testing farm test matrix, drop Fedora 40

Use tox-lsr 3.9.0 for the `--lsr-report-errors-url` argument.

Add the argument `--lsr-report-errors-url DEFAULT` to the qemu test so that
the errors will be written to the output log.  This uses the output callback
https://github.com/linux-system-roles/auto-maintenance/blob/main/callback_plugins/lsr_report_errors.py

Use the check_logs.py script
https://github.com/linux-system-roles/auto-maintenance/blob/main/check_logs.py
with the `--github-action-format` argument to format the errors
in a github action friendly manner.

Rename the log files `-FAIL.log` or `-SUCCESS.log` depending on status.
This is compatible with the way the testing farm log files are named, and
makes it easy to tell if a test passed or failed from the log file name.

Upload README.html as artifacts of the build_docs job for debugging

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Refresh CI pipelines to use the latest tox-lsr version, improve QEMU test error reporting and logging, update Fedora matrix, and expose documentation artifacts.

CI:
- Upgrade tox-lsr to 3.9.0 in QEMU, ansible-lint, ansible-managed-var-comment, and ansible-test workflows
- Add --lsr-report-errors-url DEFAULT to QEMU jobs to enable error reporting via lsr-report-errors
- Invoke check_logs.py with --github-action-format to summarize QEMU test failures in GitHub Actions
- Standardize QEMU test logs by renaming them with -SUCCESS.log or -FAIL.log suffixes
- Upload README.html as an artifact in the build_docs workflow for debugging
- Update testing farm matrix to remove Fedora-40 and include Fedora-42