### PR TITLE
docs(changelog): version 1.1.10 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -58,8 +58,9 @@ SOFTWARE.
   </style>
   <style type="text/css">code{white-space: pre;}</style>
   <style type="text/css">
+html { -webkit-text-size-adjust: 100%; }
 pre > code.sourceCode { white-space: pre; position: relative; }
-pre > code.sourceCode > span { line-height: 1.25; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
 .sourceCode { overflow: visible; }
 code.sourceCode > span { color: inherit; text-decoration: inherit; }
@@ -70,7 +71,7 @@ div.sourceCode { overflow: auto; }
 }
 @media print {
 pre > code.sourceCode { white-space: pre-wrap; }
-pre > code.sourceCode > span { display: inline-block; text-indent: -5em; padding-left: 5em; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
 }
 pre.numberSource code
   { counter-reset: source-line 0; }
@@ -225,9 +226,15 @@ alt="ansible-lint.yml" /></a> <a
 href="https://github.com/linux-system-roles/fapolicyd/actions/workflows/ansible-test.yml"><img
 src="https://github.com/linux-system-roles/fapolicyd/actions/workflows/ansible-test.yml/badge.svg"
 alt="ansible-test.yml" /></a> <a
+href="https://github.com/linux-system-roles/fapolicyd/actions/workflows/codespell.yml"><img
+src="https://github.com/linux-system-roles/fapolicyd/actions/workflows/codespell.yml/badge.svg"
+alt="codespell.yml" /></a> <a
 href="https://github.com/linux-system-roles/fapolicyd/actions/workflows/markdownlint.yml"><img
 src="https://github.com/linux-system-roles/fapolicyd/actions/workflows/markdownlint.yml/badge.svg"
 alt="markdownlint.yml" /></a> <a
+href="https://github.com/linux-system-roles/fapolicyd/actions/workflows/qemu-kvm-integration-tests.yml"><img
+src="https://github.com/linux-system-roles/fapolicyd/actions/workflows/qemu-kvm-integration-tests.yml/badge.svg"
+alt="qemu-kvm-integration-tests.yml" /></a> <a
 href="https://github.com/linux-system-roles/fapolicyd/actions/workflows/shellcheck.yml"><img
 src="https://github.com/linux-system-roles/fapolicyd/actions/workflows/shellcheck.yml/badge.svg"
 alt="shellcheck.yml" /></a> <a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 Changelog
 =========
 
+[1.1.10] - 2025-07-02
+--------------------
+
+### Other Changes
+
+- ci: ansible-plugin-scan is disabled for now (#51)
+- ci: bump ansible-lint to v25; provide collection requirements for ansible-lint (#54)
+- ci: Check spelling with codespell (#55)
+- ci: Add test plan that runs CI tests and customize it for each role (#56)
+- ci: In test plans, prefix all relate variables with SR_ (#57)
+- ci: Fix bug with ARTIFACTS_URL after prefixing with SR_ (#58)
+- ci: several changes related to new qemu test, ansible-lint, python versions, ubuntu versions (#59)
+- ci: use tox-lsr 3.6.0; improve qemu test logging (#60)
+- ci: skip storage scsi, nvme tests in github qemu ci (#61)
+- ci: Bump sclorg/testing-farm-as-github-action from 3 to 4 (#62)
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#63)
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#64)
+- ci: Add support for bootc end-to-end validation tests (#65)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#66)
+- refactor: support ansible 2.19 (#67)
+
 [1.1.9] - 2025-01-09
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.1.10

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update documentation for release 1.1.10, including changelog entries for new CI enhancements and Ansible support, and refine HTML readme styles and badges.

Documentation:
- Add v1.1.10 entry to CHANGELOG.md detailing CI improvements, test plan updates, and Ansible 2.19/Python 3.13 support
- Adjust CSS in .README.html for proper code block rendering and add Codespell and QEMU integration test workflow badges