### PR TITLE
ci: Skip reviews for PRs with [citest_skip] in the title

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,6 +8,11 @@ chat:
   art: false
 
 reviews:
+  # Skip reviews for PRs with [citest_skip] in the title
+  auto_review:
+    ignore_title_keywords:
+      - "[citest_skip]"
+
   # Disable fun features
   poem: false
   in_progress_fortune: false

--- a/contributing.md
+++ b/contributing.md
@@ -20,6 +20,12 @@ are likely to be suitable for new contributors!
 **Code** is managed on [Github](https://github.com/linux-system-roles/fapolicyd), using
 [Pull Requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
 
+## AI Coding Assistants
+
+The `.coderabbit.yaml` configuration file in the repository root contains coding
+standards and requirements that can be used by AI coding assistants to help
+generate code that follows project conventions.
+
 ## Running CI Tests Locally
 
 ### Use tox-lsr with qemu


### PR DESCRIPTION
- Add info about .coderabbit.yam for AI assistants to contributing.md
- Note that CodeRabbit uses config from the main branch so this change will apply
after this PR is merged.
