### PR TITLE
docs: fapolicyd_add_trusted_paths - dirs can be specified in the file list - add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,16 @@ Default `none` - there are four supported types of integrity. No integrity `none
 
 Default `false` - if set to `true` deploys the daemon in permissive mode.
 
+### fapolicyd_add_trusted_paths
+
+Default empty - list of files and directories that will be marked as trusted.
+Note that you cannot specify an empty directory.
+
 ### fapolicyd_add_trusted_file
 
-Default `[]` - it can take list of files that will be marked as trusted.
+Deprecated alias for `fapolicyd_add_trusted_paths`.  If `fapolicyd_add_trusted_paths`
+is not set, the role uses `fapolicyd_add_trusted_file` instead.  Prefer
+`fapolicyd_add_trusted_paths` in new playbooks.
 
 ## Example Playbook
 
@@ -50,10 +57,11 @@ Default `[]` - it can take list of files that will be marked as trusted.
     fapolicyd_setup_enable_service: true
     fapolicyd_setup_integrity: sha256
     fapolicyd_setup_trust: rpmdb,file
-    fapolicyd_add_trusted_file:
+    fapolicyd_add_trusted_paths:
       - /etc/passwd
       - /etc/fapolicyd/fapolicyd.conf
       - /etc/krb5.conf
+      - /opt/myapplication/bin  # a directory - must not be empty
   roles:
     - fapolicyd
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,10 @@ fapolicyd_setup_integrity: "{{ '' if __fapolicyd_integrity_supported
 # set permissive mode
 fapolicyd_setup_permissive: false
 
-# fapolicyd trust file management
-# list of trusted files
+# fapolicyd trust path management
+# list of trusted files and directories
+# Prefer fapolicyd_add_trusted_paths; fapolicyd_add_trusted_file is kept for
+# compatibility and is used when fapolicyd_add_trusted_paths is not set
 fapolicyd_add_trusted_file: "{{ '' if __fapolicyd_trustfiles_supported
                                 else [] }}"
+fapolicyd_add_trusted_paths: "{{ fapolicyd_add_trusted_file }}"

--- a/examples/simple.yml
+++ b/examples/simple.yml
@@ -5,7 +5,7 @@
   vars:
     fapolicyd_setup_integrity: sha256
     fapolicyd_setup_trust: rpmdb,file
-    fapolicyd_add_trusted_file:
+    fapolicyd_add_trusted_paths:
       - /etc/passwd
       - /etc/fapolicyd/fapolicyd.conf
       - /etc/krb5.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,14 +32,14 @@
     - not __fapolicyd_integrity_supported
   register: __failed_check_integrity
 
-- name: Check trust files compatibility
+- name: Check trust paths compatibility
   fail:
     msg: >-
-      Fapolicyd does not support trust files setting fapolicyd_add_trusted_file
-      on EL version < 8.4
+      Fapolicyd does not support trust paths setting fapolicyd_add_trusted_paths
+      (or fapolicyd_add_trusted_file) on EL version < 8.4
   ignore_errors: true
   when:
-    - fapolicyd_add_trusted_file | length > 0
+    - fapolicyd_add_trusted_paths | length > 0
     - not __fapolicyd_trustfiles_supported
   register: __failed_check_trusted_file
 
@@ -108,10 +108,10 @@
   changed_when: true
   failed_when: false
 
-- name: Add file to trustdb
+- name: Add path to trustdb
   command: fapolicyd-cli --file add {{ item | quote }}
-  loop: "{{ (fapolicyd_add_trusted_file is string) |
-    ternary([fapolicyd_add_trusted_file], fapolicyd_add_trusted_file) }}"
+  loop: "{{ (fapolicyd_add_trusted_paths is string) |
+    ternary([fapolicyd_add_trusted_paths], fapolicyd_add_trusted_paths) }}"
   when: item | length > 0
   changed_when: true
 

--- a/tests/tests_trusted_execution.yml
+++ b/tests/tests_trusted_execution.yml
@@ -8,6 +8,9 @@
           {{ __fapolicyd_tmpdir.path }}/executables
         __test_fpd_exe1: "{{ __test_fpd_exec_dir }}/exe1"
         __test_fpd_exe2: "{{ __test_fpd_exec_dir }}/exe2"
+        __test_fpd_dir_exec_dir: >-
+          {{ __fapolicyd_tmpdir.path }}/dir_executables
+        __test_fpd_dir_exe: "{{ __test_fpd_dir_exec_dir }}/dir_exe"
         __test_fpd_user: fapolicyd_test1_user
       block:
         # NOTE - to debug a failing execution:
@@ -35,6 +38,7 @@
           loop:
             - "{{ __fapolicyd_tmpdir.path }}"
             - "{{ __test_fpd_exec_dir }}"
+            - "{{ __test_fpd_dir_exec_dir }}"
 
         - name: Create shell executables
           copy:
@@ -48,6 +52,7 @@
           loop:
             - "{{ __test_fpd_exe1 }}"
             - "{{ __test_fpd_exe2 }}"
+            - "{{ __test_fpd_dir_exe }}"
           vars:
             __python: "{{ ansible_python_interpreter |
               d(ansible_facts['discovered_interpreter_python']) }}"
@@ -63,7 +68,7 @@
           vars:
             fapolicyd_setup_integrity: sha256
             fapolicyd_setup_trust: rpmdb,file
-            fapolicyd_add_trusted_file:
+            fapolicyd_add_trusted_paths:
               - /etc/passwd
               - /etc/fapolicyd/fapolicyd.conf
               - /etc/krb5.conf
@@ -103,7 +108,7 @@
           vars:
             fapolicyd_setup_integrity: sha256
             fapolicyd_setup_trust: rpmdb,file
-            fapolicyd_add_trusted_file: []
+            fapolicyd_add_trusted_paths: []
 
         - name: Run untrusted exe1 after removing from trustdb
           command: >-
@@ -112,6 +117,51 @@
           register: run_exe
           changed_when: false
           failed_when: run_exe.rc != 126
+
+        - name: Run the role with trusted directory
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            fapolicyd_setup_integrity: sha256
+            fapolicyd_setup_trust: rpmdb,file
+            fapolicyd_add_trusted_paths:
+              - "{{ __test_fpd_dir_exec_dir }}"
+
+        - name: Run trusted binary from trusted directory
+          command: >-
+            su - {{ __test_fpd_user | quote }} -c
+            {{ __test_fpd_dir_exe | quote }}
+          changed_when: false
+
+        - name: Run the role again without trusted directory
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            fapolicyd_setup_integrity: sha256
+            fapolicyd_setup_trust: rpmdb,file
+            fapolicyd_add_trusted_paths: []
+
+        - name: Run untrusted dir_exe after removing directory from trustdb
+          command: >-
+            su - {{ __test_fpd_user | quote }} -c
+            {{ __test_fpd_dir_exe | quote }}
+          register: run_exe
+          changed_when: false
+          failed_when: run_exe.rc != 126
+
+        # fapolicyd_add_trusted_file is deprecated but must still work
+        - name: Run the role with deprecated fapolicyd_add_trusted_file
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            fapolicyd_setup_integrity: sha256
+            fapolicyd_setup_trust: rpmdb,file
+            fapolicyd_add_trusted_file:
+              - "{{ __test_fpd_dir_exe }}"
+
+        - name: Run trusted binary using deprecated fapolicyd_add_trusted_file
+          command: >-
+            su - {{ __test_fpd_user | quote }} -c
+            {{ __test_fpd_dir_exe | quote }}
+          changed_when: false
+
       always:
         - name: Shutdown fapolicyd
           service:


### PR DESCRIPTION
Add `fapolicyd_add_trusted_paths` which is an alias for `fapolicyd_add_trusted_file`
and makes it clear that both files and directories are allowed.

Note that the role allows directories to be specified in `fapolicyd_add_trusted_file`.
A directory must not be empty.

Add a test for directories.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added and clarified `fapolicyd_add_trusted_paths` as the preferred way to configure trusted paths (supports files and non-empty directories).
  * Documented `fapolicyd_add_trusted_file` as a deprecated alias used only when `fapolicyd_add_trusted_paths` is not set.
  * Updated the example playbook to use `fapolicyd_add_trusted_paths` and added a new trusted directory example.

* **Tests**
  * Added coverage for executables placed in trusted directories, including allow-then-deny behavior after trust removal.
  * Extended checks to ensure the deprecated configuration path still works as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->